### PR TITLE
Quality awareness for create_entity()

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -221,6 +221,7 @@ script.on_event(defines.events.on_tick, function(event)
                         type                      = "accumulator",
                         name                      = "kee-intergalactic-transceiver-test-fire",
                         force                     = struct.entity.force,
+                        quality                   = struct.entity.quality,
                         player                    = struct.entity.last_user,
                         position                  = struct.entity.position,
                         create_build_effect_smoke = false
@@ -258,6 +259,7 @@ script.on_event(defines.events.on_tick, function(event)
                         type                      = "accumulator",
                         name                      = "kr-intergalactic-transceiver",
                         force                     = struct.entity.force,
+                        quality                   = struct.entity.quality,
                         player                    = struct.entity.last_user,
                         position                  = struct.entity.position,
                         create_build_effect_smoke = false,
@@ -285,6 +287,7 @@ script.on_event(defines.events.on_tick, function(event)
                     type                      = "container",
                     name                      = "kee-intergalactic-transceiver-loading",
                     force                     = struct.entity.force,
+                    quality                   = struct.entity.quality,
                     player                    = struct.entity.last_user,
                     position                  = struct.entity.position,
                     create_build_effect_smoke = false


### PR DESCRIPTION
Adding "Quality" was simpler then I thought.
I tested it with K2, K2+Quality and K2 Spaced out (space age)
<img width="629" height="805" alt="image" src="https://github.com/user-attachments/assets/957ede1c-169f-4c0d-913c-6dea91a57f32" />
